### PR TITLE
Add local alias file option and CK alias updates

### DIFF
--- a/src/main/java/org/magic/services/MTGConstants.java
+++ b/src/main/java/org/magic/services/MTGConstants.java
@@ -43,6 +43,7 @@ public class MTGConstants {
 	public static final File NATIVE_DIR = new File("./natives");
 	public static final URL TOOLTIPS_FILE = MTGConstants.class.getResource("/data/tips.properties");
 	public static final Image SAMPLE_PIC = Toolkit.getDefaultToolkit().getImage(MTGConstants.class.getResource("/data/sample.png"));
+	public static final File MTG_DESKTOP_ALIASES_FILE = new File("./src/main/resources/data/pluginsAliases.json");
 	
 	public static final float WEIGHT_CARD=1.7009714f;
 	public static final float WEIGHT_BOOSTER=28.7f;

--- a/src/main/java/org/magic/services/providers/PluginsAliasesProvider.java
+++ b/src/main/java/org/magic/services/providers/PluginsAliasesProvider.java
@@ -7,6 +7,7 @@ import org.magic.api.interfaces.MTGPlugin;
 import org.magic.services.MTGConstants;
 import org.magic.services.MTGLogger;
 import org.magic.services.network.URLTools;
+import org.magic.tools.FileTools;
 
 import com.google.gson.JsonObject;
 
@@ -15,6 +16,7 @@ public class PluginsAliasesProvider {
 	private JsonObject jsonData;
 	private Logger logger = MTGLogger.getLogger(PluginsAliasesProvider.class);
 	private static PluginsAliasesProvider inst;
+	private boolean LocalAliases = false; //true uses local source
 	
 	public static PluginsAliasesProvider inst()
 	{
@@ -27,12 +29,24 @@ public class PluginsAliasesProvider {
 	
 	
 	private PluginsAliasesProvider() {
+		
+		if (LocalAliases) {
+			try {
+				logger.error(MTGConstants.MTG_DESKTOP_ALIASES_FILE);
+			jsonData = FileTools.readJson(MTGConstants.MTG_DESKTOP_ALIASES_FILE).getAsJsonObject();
+			}
+			catch(Exception e) {
+				logger.error("No Error getting file "+  MTGConstants.MTG_DESKTOP_ALIASES_URL + " :"+e);
+			}
+		}
+		else {
 		try {
 			jsonData = URLTools.extractAsJson(MTGConstants.MTG_DESKTOP_ALIASES_URL).getAsJsonObject();
 		}
 		catch(Exception e)
 		{
 			logger.error("No Error getting file "+  MTGConstants.MTG_DESKTOP_ALIASES_URL + " :"+e);
+		}
 		}
 	}
 	

--- a/src/main/resources/data/pluginsAliases.json
+++ b/src/main/resources/data/pluginsAliases.json
@@ -4,7 +4,11 @@
 			"Ravnica: City of Guilds": "Ravnica",
 			"Zendikar Rising Commander": "Zendikar Rising Commander Decks",
 			"Mystery Booster":"Mystery Booster/The List",
-			"The List":"Mystery Booster/The List"
+			"The List":"Mystery Booster/The List",
+			"GRN Guild Kit":"Guilds Of Ravnica: Guild Kits",
+			"RNA Guild Kit":"Ravnica Allegiance: Guild Kits",
+			"Forgotten Realms Commander":"Adventures In The Forgotten Realms Commander Decks",
+			"Archenemy: Nicol Bolas":"Archenemy - Nicol Bolas"
 		}
 	},
 	"DeckBox":{


### PR DESCRIPTION
Added a section in the PluginsAliasesProvider that can be set to swap between using the web aliases or a local alias. I found myself swapping this for testing constantly (and forgetting how to do it each time). There is a bool that can be set to true or false that will switch it. I have it set to false so should be no change for users. Not sure if something like this is appropriate. Also there is no GUI switch for this. Only source.

Some updates for the CardKingdom export aliases as well.