### PR TITLE
Add new search term for Moxfield Decksniffer

### DIFF
--- a/src/main/java/org/magic/api/decksniffer/impl/MoxfieldDeckSniffer.java
+++ b/src/main/java/org/magic/api/decksniffer/impl/MoxfieldDeckSniffer.java
@@ -33,7 +33,7 @@ public class MoxfieldDeckSniffer extends AbstractDeckSniffer {
 
 	@Override
 	public String[] listFilter() {
-		return new String[]{"Archon","highlanderAustralian","Brawl","highlanderCanadian","Centurion","Commander","CommanderPrecons","Conquest","DuelCommander","Gladiator","Historic","HistoricBrawl","Legacy","Leviathan","Modern","OldSchool","Oathbreaker","Pauper","PauperEDH","PennyDreadful","Pioneer","Premodern","Primordial","Standard","Vintage","None"};
+		return new String[]{"Archon","highlanderAustralian","Brawl","highlanderCanadian","Centurion","Commander","CommanderPrecons","Conquest","DuelCommander","Gladiator","Historic","HistoricBrawl","Legacy","Leviathan","Modern","OldSchool","Oathbreaker","Pauper","PauperEDH","PennyDreadful","Pioneer","Precons","Premodern","Primordial","Standard","Vintage","None"};
 	}
 
 	@Override


### PR DESCRIPTION
I've seen the Decksniffer for Moxfield and noticed that in couldn't find any non Commander precons. I think I didn't miss a spot to add another "Format" for Moxfield deck search via api. I've tested my change successfully on windows 10 with openjdk 21.