### PR TITLE
chore(maven): améliorer pom.xml et retirer slf4j-nop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,20 +22,22 @@
 			<name>Nicolas Pihen</name>
 			<email>nicolas.pihen@gmail.com</email>
 			<url>https://github.com/nicho92/</url>
+			<roles>
+				<role>owner</role>
+				<role>developer</role>
+			</roles>
 		</developer>
 	</developers>
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
+			<distribution>repo</distribution>
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:https://github.com/nicho92/MtgDesktopCompanion.git
-		</connection>
-		<developerConnection>
-			scm:git:https://github.com/nicho92/MtgDesktopCompanion.git
-		</developerConnection>
+		<connection>scm:git:https://github.com/nicho92/MtgDesktopCompanion.git</connection>
+		<developerConnection>scm:git:https://github.com/nicho92/MtgDesktopCompanion.git</developerConnection>
 		<url>https://github.com/nicho92/MtgDesktopCompanion</url>
 		<tag>HEAD</tag>
 	</scm>
@@ -216,11 +218,6 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-nop</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
### Motivation
- Compléter et normaliser les métadonnées du projet dans le `pom.xml` (section `developers`, `licenses`, `scm`) pour une meilleure lisibilité et conformité.
- Éviter les bindings de logging conflictuels en supprimant la dépendance redondante `org.slf4j:slf4j-nop` qui entre en conflit avec `log4j-slf4j2-impl`.

### Description
- Ajout des rôles explicites pour le développeur dans la section `developers` (`owner`, `developer`).
- Passage de l’URL de licence Apache à `https://` et ajout de `<distribution>repo</distribution>` dans la section `licenses`.
- Normalisation des balises `connection` et `developerConnection` de la section `scm` sur une seule ligne pour un POM plus propre.
- Suppression de la dépendance `org.slf4j:slf4j-nop` tout en conservant `org.slf4j:slf4j-api` et `log4j-slf4j2-impl` pour éviter les bindings concurrents.

### Testing
- Exécution de `mvn -q -DskipTests validate` — réussite.
- Tentative d’exécution de `mvn -q -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.8.1:analyze` — échec de résolution du plugin (HTTP 403 depuis Maven Central) donc l’analyse automatique des dépendances n’a pas pu s’exécuter.
- Les modifications ont été ajoutées et validées avec `git commit` (message: "chore(maven): clean pom metadata and logging deps").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49b5e01ec8333bc2afb4656b607f7)