### PR TITLE
Update BoofCV to 1.4.0 and adapt SURF/descriptors + line detection APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
 		<dependency>
 			<groupId>org.boofcv</groupId>
 			<artifactId>boofcv-core</artifactId>
-			<version>0.35</version>
+			<version>1.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.sarxos</groupId>

--- a/src/main/java/org/magic/services/recognition/ImageDesc.java
+++ b/src/main/java/org/magic/services/recognition/ImageDesc.java
@@ -7,11 +7,12 @@ import boofcv.alg.descriptor.UtilFeature;
 import boofcv.alg.enhance.EnhanceImageOps;
 import boofcv.alg.misc.ImageStatistics;
 import boofcv.core.image.ConvertImage;
+import boofcv.factory.feature.associate.ConfigAssociateGreedy;
 import boofcv.factory.feature.associate.FactoryAssociation;
 import boofcv.factory.feature.detdesc.FactoryDetectDescribe;
 import boofcv.io.image.ConvertBufferedImage;
 import boofcv.struct.feature.AssociatedIndex;
-import boofcv.struct.feature.BrightFeature;
+import boofcv.struct.feature.TupleDesc_F64;
 import boofcv.struct.image.GrayF32;
 import boofcv.struct.image.GrayU8;
 import georegression.struct.point.Point2D_F64;
@@ -21,7 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import org.ddogleg.struct.FastQueue;
+import org.ddogleg.struct.DogArray;
 
 public class ImageDesc {
 
@@ -33,7 +34,7 @@ public class ImageDesc {
 	private static int numberOfOctaves = 4;
 	private static int maxFeaturesPerScale = 50;
 
-	private static DetectDescribePoint<GrayF32, BrightFeature> detDesc = FactoryDetectDescribe
+	private static DetectDescribePoint<GrayF32, TupleDesc_F64> detDesc = FactoryDetectDescribe
 			.surfStable(getHessianConf(), null, null, GrayF32.class);
 
 	private static ConfigFastHessian getHessianConf() {
@@ -41,13 +42,13 @@ public class ImageDesc {
 				initialSize, numberScalesPerOctave, numberOfOctaves);
 	}
 
-	private static ScoreAssociation<BrightFeature> scorer = FactoryAssociation
+	private static ScoreAssociation<TupleDesc_F64> scorer = FactoryAssociation
 			.defaultScore(detDesc.getDescriptionType());
-	private static AssociateDescription<BrightFeature> associate = FactoryAssociation.greedy(scorer, 8, true);
+	private static AssociateDescription<TupleDesc_F64> associate = FactoryAssociation.greedy(new ConfigAssociateGreedy(true), scorer);
 
 	private AverageHash hash;
 	private AverageHash flipped;
-	private FastQueue<BrightFeature> desc = UtilFeature.createQueue(detDesc, 0);
+	private DogArray<TupleDesc_F64> desc = UtilFeature.createArray(detDesc, 0);
 	private List<Point2D_F64> points = new ArrayList<>(0);
 	private int size;
 
@@ -76,7 +77,7 @@ public class ImageDesc {
 		this(in, null);
 	}
 
-	private ImageDesc(FastQueue<BrightFeature> d, List<Point2D_F64> p, AverageHash h) {
+	private ImageDesc(DogArray<TupleDesc_F64> d, List<Point2D_F64> p, AverageHash h) {
 		desc = d;
 		hash = h;
 		points = p;
@@ -86,7 +87,7 @@ public class ImageDesc {
 	public void writeOut(DataOutputStream out) throws IOException {
 		out.writeInt(size);
 		for (var i = 0; i < size; i++) {
-			BrightFeature f = desc.get(i);
+			TupleDesc_F64 f = desc.get(i);
 			for (double val : f.value) {
 				out.writeDouble(val);
 			}
@@ -100,7 +101,7 @@ public class ImageDesc {
 	public static ImageDesc readIn(ByteBuffer buf) {
 		var size = buf.getInt();
 		List<Point2D_F64> points = new ArrayList<>(size);
-		FastQueue<BrightFeature> descs = UtilFeature.createQueue(detDesc, size);
+		DogArray<TupleDesc_F64> descs = UtilFeature.createArray(detDesc, size);
 		for (var i = 0; i < size; i++) {
 			var f = detDesc.createDescription();
 			for (var j = 0; j < f.size(); j++) {
@@ -113,7 +114,7 @@ public class ImageDesc {
 		return new ImageDesc(descs, points, hash);
 	}
 
-	private static int describeImage(GrayF32 input, FastQueue<BrightFeature> descs, List<Point2D_F64> points) {
+	private static int describeImage(GrayF32 input, DogArray<TupleDesc_F64> descs, List<Point2D_F64> points) {
 		detDesc.detect(input);
 		var size = detDesc.getNumberOfFeatures();
 		for (var i = 0; i < size; i++) {
@@ -129,7 +130,7 @@ public class ImageDesc {
 		associate.associate();
 
 		double max = Math.max(desc.size(), i2.desc.size());
-		FastQueue<AssociatedIndex> matches = associate.getMatches();
+		DogArray<AssociatedIndex> matches = associate.getMatches();
 		double score = 0;
 		for (var i = 0; i < matches.size(); i++) {
 			AssociatedIndex match = matches.get(i);

--- a/src/main/java/org/magic/services/recognition/area/RadiusAreaStrat.java
+++ b/src/main/java/org/magic/services/recognition/area/RadiusAreaStrat.java
@@ -1,21 +1,10 @@
 package org.magic.services.recognition.area;
 import boofcv.abst.feature.detect.line.DetectLineSegment;
-import boofcv.abst.feature.detect.line.DetectLineSegmentsGridRansac;
-import boofcv.abst.filter.derivative.ImageGradient;
-import boofcv.alg.feature.detect.line.ConnectLinesGrid;
-import boofcv.alg.feature.detect.line.GridRansacLineDetector;
-import boofcv.alg.feature.detect.line.gridline.Edgel;
-import boofcv.alg.feature.detect.line.gridline.GridLineModelDistance;
-import boofcv.alg.feature.detect.line.gridline.GridLineModelFitter;
-import boofcv.alg.feature.detect.line.gridline.ImplGridRansacLineDetector_S16;
 import boofcv.alg.filter.blur.GBlurImageOps;
 import boofcv.factory.feature.detect.line.ConfigLineRansac;
-import boofcv.factory.filter.derivative.FactoryDerivative;
+import boofcv.factory.feature.detect.line.FactoryDetectLine;
 import boofcv.io.image.ConvertBufferedImage;
-import boofcv.struct.image.GrayS16;
 import boofcv.struct.image.GrayU8;
-import georegression.fitting.line.ModelManagerLinePolar2D_F32;
-import georegression.struct.line.LinePolar2D_F32;
 import georegression.struct.line.LineSegment2D_F32;
 import georegression.struct.point.Point2D_F32;
 import georegression.struct.point.Point2D_I32;
@@ -27,8 +16,6 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.ddogleg.fitting.modelset.ModelMatcher;
-import org.ddogleg.fitting.modelset.ransac.Ransac;
 import org.magic.api.interfaces.MTGCardRecognition;
 import org.magic.gui.abstracts.AbstractRecognitionArea;
 import org.magic.services.recognition.ContourBoundingBox;
@@ -89,7 +76,7 @@ public class RadiusAreaStrat extends AbstractRecognitionArea {
 			GBlurImageOps.gaussian(input, blurred, 0, blurRad, null);
 
 			if (configChanged) {
-				detector = this.lineRansac(config, 60, 2);
+				detector = FactoryDetectLine.lineRansac(config, GrayU8.class);
 				configChanged = false;
 			}
 			frameSegments.addAll(detector.detect(blurred));
@@ -413,31 +400,4 @@ public class RadiusAreaStrat extends AbstractRecognitionArea {
 		// do nothing
 	}
 
-	/**
-	 * Derived from the BoofCV factory source code, but exposes the RANSAC
-	 * iterations and the max lines per grid region
-	 */
-	private DetectLineSegmentsGridRansac<GrayU8, GrayS16> lineRansac(ConfigLineRansac config, int maxIter,
-			int maxLines) {
-
-		if (config == null)
-			config = new ConfigLineRansac();
-
-		ImageGradient<GrayU8, GrayS16> gradient = FactoryDerivative.sobel(GrayU8.class, GrayS16.class);
-
-		var manager = new ModelManagerLinePolar2D_F32();
-		var distance = new GridLineModelDistance((float) config.thresholdAngle);
-		var fitter = new GridLineModelFitter((float) config.thresholdAngle);
-
-		ModelMatcher<LinePolar2D_F32, Edgel> matcher = new Ransac<>(123123, manager, fitter, distance, maxIter, 0.25);
-
-		GridRansacLineDetector<GrayS16> alg = new ImplGridRansacLineDetector_S16(config.regionSize, maxLines, matcher);
-
-		ConnectLinesGrid connect = null;
-		if (config.connectLines)
-			connect = new ConnectLinesGrid(Math.PI * 0.01, 1, 8);
-
-		return new DetectLineSegmentsGridRansac<>(alg, connect, gradient, config.thresholdEdge, GrayU8.class,
-				GrayS16.class);
-	}
 }


### PR DESCRIPTION
### Motivation
- Address a security/compatibility request to move the BoofCV dependency to the latest `1.4.0` release.  
- Update usage of BoofCV APIs that changed between `0.35` and `1.4.0` to avoid runtime breakage and to use public factory APIs.  
- Replace fragile internal-class usage with current public types and factories to reduce maintenance and security risk.  

### Description
- Bumped `org.boofcv:boofcv-core` from `0.35` to `1.4.0` in `pom.xml`.  
- Migrated SURF descriptor code in `src/main/java/org/magic/services/recognition/ImageDesc.java` from `BrightFeature`/`FastQueue` to BoofCV `TupleDesc_F64`/`DogArray`, updated association to use `ConfigAssociateGreedy` and `FactoryAssociation.greedy`, and replaced `UtilFeature.createQueue` with `UtilFeature.createArray`; updated related method signatures and read/write logic to match the new descriptor types.  
- Replaced the custom/internal RANSAC/line-detector implementation in `src/main/java/org/magic/services/recognition/area/RadiusAreaStrat.java` with the public factory call `FactoryDetectLine.lineRansac(config, GrayU8.class)`, removing reliance on internal line-detector internals and cleaning up unused imports and code.  

### Testing
- Ran `git diff --check` to validate whitespace/format issues and local diffs (no problems reported).  
- Attempted `mvn -q -DskipTests compile` to compile changes, but the build could not complete due to environment/network resolution returning HTTP `403 Forbidden` while resolving `maven-resources-plugin:3.3.1` from Maven Central, so compilation could not be verified in this environment.  
- Performed targeted source updates and grep checks (`rg`) to confirm API usages and imports were replaced; no unit/integration tests were executed because the Maven build did not finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46be76d350833385c1498bd10df1ad)